### PR TITLE
obniz-cliにシリアル選択肢

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ $obniz-cli os:flash
 Flash obnizOS and configure it
 
 [serial setting]
- -p --port      serial port path to flash. If not specified. will be automatically selected.
+ -p --port      serial port path to flash.If not specified, the port list will be displayed.
  -b --baud      flashing baud rate. default to 1500000
 
 [flashing setting]

--- a/dist/index.js
+++ b/dist/index.js
@@ -20,11 +20,10 @@ const erase_1 = __importDefault(require("./libs/os/erase"));
 const flash_1 = __importDefault(require("./libs/os/flash"));
 const flashcreate_1 = __importDefault(require("./libs/os/flashcreate"));
 const list_1 = __importDefault(require("./libs/os/list"));
-const guess_1 = __importDefault(require("./libs/os/serial/guess"));
+const prepare_1 = __importDefault(require("./libs/os/serial/prepare"));
 const info_1 = __importDefault(require("./libs/user/info"));
 const login_1 = __importDefault(require("./libs/user/login"));
 const logout_1 = __importDefault(require("./libs/user/logout"));
-const defaults_1 = __importDefault(require("./defaults"));
 const relative = "../";
 const packageverion = require(`${relative}package.json`).version;
 // ========== Global Errors =========
@@ -37,27 +36,6 @@ process.on("unhandledRejection", (err) => {
     throw err;
 });
 // ========== Routes =========
-async function preparePort(args) {
-    let portname = args.p || args.port;
-    if (!portname) {
-        portname = await guess_1.default();
-        if (portname) {
-            console.log(`Guessed Serial Port ${portname}`);
-        }
-    }
-    let baud = args.b || args.baud;
-    if (!baud) {
-        baud = defaults_1.default.BAUD;
-    }
-    if (!portname) {
-        console.log(`No port defined. And auto detect failed`);
-        process.exit(0);
-    }
-    return {
-        portname,
-        baud,
-    };
-}
 const routes = {
     "signin": {
         help: `Signin to obniz Cloud`,
@@ -82,7 +60,7 @@ const routes = {
     "os:config": config_1.default,
     "os:erase": {
         async execute(args) {
-            const obj = await preparePort(args);
+            const obj = await prepare_1.default(args);
             obj.stdout = (text) => {
                 process.stdout.write(text);
             };

--- a/dist/libs/os/config.js
+++ b/dist/libs/os/config.js
@@ -17,33 +17,12 @@ const defaults_1 = __importDefault(require("../../defaults"));
 const device_1 = __importDefault(require("../obnizio/device"));
 const Storage = __importStar(require("../storage"));
 const configure_1 = __importDefault(require("./configure"));
-const guess_1 = __importDefault(require("./serial/guess"));
-async function preparePort(args) {
-    let portname = args.p || args.port;
-    if (!portname) {
-        portname = await guess_1.default();
-        if (portname) {
-            console.log(`Guessed Serial Port ${portname}`);
-        }
-    }
-    let baud = args.b || args.baud;
-    if (!baud) {
-        baud = defaults_1.default.BAUD;
-    }
-    if (!portname) {
-        console.log(`No port defined. And auto detect failed`);
-        process.exit(0);
-    }
-    return {
-        portname,
-        baud,
-    };
-}
+const prepare_1 = __importDefault(require("./serial/prepare"));
 exports.default = {
     help: `Flash obnizOS and configure it
 
 [serial setting]
- -p --port        serial port path to flash. If not specified. will be automatically selected.
+ -p --port        serial port path to flash.If not specified, the port list will be displayed.
  -b --baud        flashing baud rate. default to ${defaults_1.default.BAUD}
 
  [configrations]
@@ -53,7 +32,7 @@ exports.default = {
   `,
     async execute(args) {
         // Serial Port Setting
-        const obj = await preparePort(args);
+        const obj = await prepare_1.default(args);
         obj.stdout = (text) => {
             process.stdout.write(text);
         };

--- a/dist/libs/os/flash.js
+++ b/dist/libs/os/flash.js
@@ -8,33 +8,12 @@ const defaults_1 = __importDefault(require("../../defaults"));
 const os_1 = __importDefault(require("../../libs/obnizio/os"));
 const _flash_1 = __importDefault(require("./_flash"));
 const config_1 = __importDefault(require("./config"));
-const guess_1 = __importDefault(require("./serial/guess"));
-async function preparePort(args) {
-    let portname = args.p || args.port;
-    if (!portname) {
-        portname = await guess_1.default();
-        if (portname) {
-            console.log(`Guessed Serial Port ${portname}`);
-        }
-    }
-    let baud = args.b || args.baud;
-    if (!baud) {
-        baud = defaults_1.default.BAUD;
-    }
-    if (!portname) {
-        console.log(`No port defined. And auto detect failed`);
-        process.exit(0);
-    }
-    return {
-        portname,
-        baud,
-    };
-}
+const prepare_1 = __importDefault(require("./serial/prepare"));
 exports.default = {
     help: `Flash obnizOS and configure it
 
 [serial setting]
- -p --port      serial port path to flash. If not specified. will be automatically selected.
+ -p --port      serial port path to flash.If not specified, the port list will be displayed.
  -b --baud      flashing baud rate. default to ${defaults_1.default.BAUD}
 
 [flashing setting]
@@ -48,7 +27,7 @@ exports.default = {
   `,
     async execute(args) {
         // flashing os
-        const obj = await preparePort(args);
+        const obj = await prepare_1.default(args);
         obj.stdout = (text) => {
             process.stdout.write(text);
         };

--- a/dist/libs/os/flashcreate.js
+++ b/dist/libs/os/flashcreate.js
@@ -17,33 +17,12 @@ const device_1 = __importDefault(require("../obnizio/device"));
 const Storage = __importStar(require("../storage"));
 const _flash_1 = __importDefault(require("./_flash"));
 const config_1 = __importDefault(require("./config"));
-const guess_1 = __importDefault(require("./serial/guess"));
-async function preparePort(args) {
-    let portname = args.p || args.port;
-    if (!portname) {
-        portname = await guess_1.default();
-        if (portname) {
-            console.log(`Guessed Serial Port ${portname}`);
-        }
-    }
-    let baud = args.b || args.baud;
-    if (!baud) {
-        baud = defaults_1.default.BAUD;
-    }
-    if (!portname) {
-        console.log(`No port defined. And auto detect failed`);
-        process.exit(0);
-    }
-    return {
-        portname,
-        baud,
-    };
-}
+const prepare_1 = __importDefault(require("./serial/prepare"));
 exports.default = {
     help: `Flash obnizOS and configure it
 
 [serial setting]
- -p --port        serial port path to flash. If not specified. will be automatically selected.
+ -p --port        serial port path to flash.If not specified, the port list will be displayed.
  -b --baud        flashing baud rate. default to ${defaults_1.default.BAUD}
 
 [flashing setting]
@@ -67,7 +46,7 @@ exports.default = {
             throw new Error(`You must singin before create device`);
         }
         // SerialPortSetting
-        const obj = await preparePort(args);
+        const obj = await prepare_1.default(args);
         obj.stdout = (text) => {
             process.stdout.write(text);
         };

--- a/dist/libs/os/ports.js
+++ b/dist/libs/os/ports.js
@@ -7,7 +7,8 @@ const serialport_1 = __importDefault(require("serialport"));
 exports.default = async () => {
     const ports = await serialport_1.default.list();
     console.log(`===Found Serial Ports===`);
-    for (const port of ports) {
-        console.log(`${port.path}`);
+    for (let i = 0; i < ports.length; i++) {
+        console.log(`${i}: ${ports[i].path}`);
     }
+    return ports;
 };

--- a/dist/libs/os/serial/prepare.js
+++ b/dist/libs/os/serial/prepare.js
@@ -1,0 +1,80 @@
+"use strict";
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
+    result["default"] = mod;
+    return result;
+};
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const readline = __importStar(require("readline"));
+const defaults_1 = __importDefault(require("../../../defaults"));
+const ports_1 = __importDefault(require("../ports"));
+const guess_1 = __importDefault(require("./guess"));
+exports.default = async (args) => {
+    let portname = args.p || args.port;
+    if (!portname) {
+        console.log("No port specified.");
+        // display port list
+        const ports = await ports_1.default();
+        const guessed_portname = await guess_1.default();
+        if (guessed_portname) {
+            console.log(`Guessed Serial Port ${portname}`);
+            const use = await askUseGuessedPort(guessed_portname);
+            if (use) {
+                portname = guessed_portname;
+            }
+        }
+        if (!portname) {
+            const selected = await selectPort(ports);
+            portname = selected;
+        }
+    }
+    let baud = args.b || args.baud;
+    if (!baud) {
+        baud = defaults_1.default.BAUD;
+    }
+    return {
+        portname,
+        baud,
+    };
+};
+function askUseGuessedPort(guessed_portname) {
+    const rl = readline.createInterface({
+        input: process.stdin,
+        output: process.stdout,
+    });
+    return new Promise((resolve, reject) => {
+        rl.question(`Use guessed port(${guessed_portname}?) (y or n)`, (answer) => {
+            if (answer === "y") {
+                resolve(true);
+            }
+            else if (answer === "n") {
+                resolve(false);
+            }
+            else {
+                reject(new Error("Enter y or n"));
+            }
+        });
+    });
+}
+function selectPort(ports) {
+    const rl = readline.createInterface({
+        input: process.stdin,
+        output: process.stdout,
+    });
+    return new Promise((resolve, reject) => {
+        rl.question(`Select a port from the list above. (integer from 0 to ${ports.length - 1})`, (answer) => {
+            const selected = ports[answer];
+            if (selected) {
+                resolve(selected.path);
+            }
+            else {
+                reject(new Error(`Enter integer from 0 to ${ports.length - 1}`));
+            }
+        });
+    });
+}

--- a/dist/libs/os/serial/prepare.js
+++ b/dist/libs/os/serial/prepare.js
@@ -22,7 +22,7 @@ exports.default = async (args) => {
         const ports = await ports_1.default();
         const guessed_portname = await guess_1.default();
         if (guessed_portname) {
-            console.log(`Guessed Serial Port ${portname}`);
+            console.log(`Guessed Serial Port ${guessed_portname}`);
             const use = await askUseGuessedPort(guessed_portname);
             if (use) {
                 portname = guessed_portname;

--- a/dist/libs/user/login.js
+++ b/dist/libs/user/login.js
@@ -17,5 +17,5 @@ exports.default = async () => {
     const token = await login_1.default();
     const user = await user_1.default(token);
     Storage.set("token", token);
-    console.log(`Sigin in as "${user.email}"`);
+    console.log(`Sign in as "${user.email}"`);
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,13 +11,11 @@ import Erase from "./libs/os/erase";
 import Flash from "./libs/os/flash";
 import Create from "./libs/os/flashcreate";
 import List from "./libs/os/list";
-import SerialGuess from "./libs/os/serial/guess";
+import PreparePort from "./libs/os/serial/prepare";
 
 import UserInfo from "./libs/user/info";
 import Login from "./libs/user/login";
 import Logout from "./libs/user/logout";
-
-import Defaults from "./defaults";
 
 const relative = "../";
 
@@ -36,29 +34,6 @@ process.on("unhandledRejection", (err) => {
 });
 
 // ========== Routes =========
-
-async function preparePort(args: any): Promise<any> {
-  let portname: string = args.p || args.port;
-  if (!portname) {
-    portname = await SerialGuess();
-    if (portname) {
-      console.log(`Guessed Serial Port ${portname}`);
-    }
-  }
-  let baud: any = args.b || args.baud;
-  if (!baud) {
-    baud = Defaults.BAUD;
-  }
-  if (!portname) {
-    console.log(`No port defined. And auto detect failed`);
-    process.exit(0);
-  }
-  return {
-    portname,
-    baud,
-  };
-}
-
 const routes = {
   "signin": {
     help: `Signin to obniz Cloud`,
@@ -83,7 +58,7 @@ const routes = {
   "os:config": Config,
   "os:erase": {
     async execute(args: any) {
-      const obj = await preparePort(args);
+      const obj = await PreparePort(args);
       obj.stdout = (text: string) => {
         process.stdout.write(text);
       };

--- a/src/libs/os/config.ts
+++ b/src/libs/os/config.ts
@@ -5,35 +5,13 @@ import Defaults from "../../defaults";
 import Device from "../obnizio/device";
 import * as Storage from "../storage";
 import Config from "./configure";
-import SerialGuess from "./serial/guess";
-
-async function preparePort(args: any): Promise<any> {
-  let portname: string = args.p || args.port;
-  if (!portname) {
-    portname = await SerialGuess();
-    if (portname) {
-      console.log(`Guessed Serial Port ${portname}`);
-    }
-  }
-  let baud: any = args.b || args.baud;
-  if (!baud) {
-    baud = Defaults.BAUD;
-  }
-  if (!portname) {
-    console.log(`No port defined. And auto detect failed`);
-    process.exit(0);
-  }
-  return {
-    portname,
-    baud,
-  };
-}
+import PreparePort from "./serial/prepare";
 
 export default {
   help: `Flash obnizOS and configure it
 
 [serial setting]
- -p --port        serial port path to flash. If not specified. will be automatically selected.
+ -p --port        serial port path to flash.If not specified, the port list will be displayed.
  -b --baud        flashing baud rate. default to ${Defaults.BAUD}
 
  [configrations]
@@ -43,7 +21,7 @@ export default {
   `,
   async execute(args: any) {
     // Serial Port Setting
-    const obj = await preparePort(args);
+    const obj = await PreparePort(args);
     obj.stdout = (text: string) => {
       process.stdout.write(text);
     };

--- a/src/libs/os/flash.ts
+++ b/src/libs/os/flash.ts
@@ -3,35 +3,13 @@ import Defaults from "../../defaults";
 import OS from "../../libs/obnizio/os";
 import Flash from "./_flash";
 import Config from "./config";
-import SerialGuess from "./serial/guess";
-
-async function preparePort(args: any): Promise<any> {
-  let portname: string = args.p || args.port;
-  if (!portname) {
-    portname = await SerialGuess();
-    if (portname) {
-      console.log(`Guessed Serial Port ${portname}`);
-    }
-  }
-  let baud: any = args.b || args.baud;
-  if (!baud) {
-    baud = Defaults.BAUD;
-  }
-  if (!portname) {
-    console.log(`No port defined. And auto detect failed`);
-    process.exit(0);
-  }
-  return {
-    portname,
-    baud,
-  };
-}
+import PreparePort from "./serial/prepare";
 
 export default {
   help: `Flash obnizOS and configure it
 
 [serial setting]
- -p --port      serial port path to flash. If not specified. will be automatically selected.
+ -p --port      serial port path to flash.If not specified, the port list will be displayed.
  -b --baud      flashing baud rate. default to ${Defaults.BAUD}
 
 [flashing setting]
@@ -45,7 +23,7 @@ export default {
   `,
   async execute(args: any) {
     // flashing os
-    const obj: any = await preparePort(args);
+    const obj: any = await PreparePort(args);
     obj.stdout = (text) => {
       process.stdout.write(text);
     };

--- a/src/libs/os/flashcreate.ts
+++ b/src/libs/os/flashcreate.ts
@@ -5,35 +5,13 @@ import Device from "../obnizio/device";
 import * as Storage from "../storage";
 import Flash from "./_flash";
 import Config from "./config";
-import SerialGuess from "./serial/guess";
-
-async function preparePort(args: any): Promise<any> {
-  let portname: string = args.p || args.port;
-  if (!portname) {
-    portname = await SerialGuess();
-    if (portname) {
-      console.log(`Guessed Serial Port ${portname}`);
-    }
-  }
-  let baud: any = args.b || args.baud;
-  if (!baud) {
-    baud = Defaults.BAUD;
-  }
-  if (!portname) {
-    console.log(`No port defined. And auto detect failed`);
-    process.exit(0);
-  }
-  return {
-    portname,
-    baud,
-  };
-}
+import PreparePort from "./serial/prepare";
 
 export default {
   help: `Flash obnizOS and configure it
 
 [serial setting]
- -p --port        serial port path to flash. If not specified. will be automatically selected.
+ -p --port        serial port path to flash.If not specified, the port list will be displayed.
  -b --baud        flashing baud rate. default to ${Defaults.BAUD}
 
 [flashing setting]
@@ -59,7 +37,7 @@ export default {
     }
 
     // SerialPortSetting
-    const obj: any = await preparePort(args);
+    const obj: any = await PreparePort(args);
     obj.stdout = (text: string) => {
       process.stdout.write(text);
     };

--- a/src/libs/os/ports.ts
+++ b/src/libs/os/ports.ts
@@ -4,7 +4,9 @@ export default async () => {
   const ports: SerialPort.PortInfo[] = await SerialPort.list();
   console.log(`===Found Serial Ports===`);
 
-  for (const port of ports) {
-    console.log(`${port.path}`);
+  for (let i = 0; i < ports.length; i++) {
+    console.log(`${i}: ${ports[i].path}`);
   }
+
+  return ports;
 };

--- a/src/libs/os/serial/prepare.ts
+++ b/src/libs/os/serial/prepare.ts
@@ -1,0 +1,76 @@
+import * as readline from "readline";
+
+import Defaults from "../../../defaults";
+import Ports from "../ports";
+import SerialGuess from "./guess";
+
+export default async (args: any): Promise<any> => {
+  let portname: string = args.p || args.port;
+
+  if (!portname) {
+    console.log("No port specified.");
+    // display port list
+    const ports = await Ports();
+
+    const guessed_portname = await SerialGuess();
+    if (guessed_portname) {
+      console.log(`Guessed Serial Port ${portname}`);
+      const use = await askUseGuessedPort(guessed_portname);
+      if (use) {
+        portname = guessed_portname;
+      }
+    }
+
+    if (!portname) {
+      const selected = await selectPort(ports);
+      portname = selected;
+    }
+  }
+
+  let baud: any = args.b || args.baud;
+  if (!baud) {
+    baud = Defaults.BAUD;
+  }
+
+  return {
+    portname,
+    baud,
+  };
+};
+
+function askUseGuessedPort(guessed_portname: string): Promise<boolean> {
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+
+  return new Promise((resolve, reject) => {
+    rl.question(`Use guessed port(${guessed_portname}?) (y or n)`, (answer) => {
+      if (answer === "y") {
+        resolve(true);
+      } else if (answer === "n") {
+        resolve(false);
+      } else {
+        reject(new Error("Enter y or n"));
+      }
+    });
+  });
+}
+
+function selectPort(ports: any): Promise<string> {
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+
+  return new Promise((resolve, reject) => {
+    rl.question(`Select a port from the list above. (integer from 0 to ${ports.length - 1})`, (answer) => {
+      const selected = ports[answer];
+      if (selected) {
+        resolve(selected.path);
+      } else {
+        reject(new Error(`Enter integer from 0 to ${ports.length - 1}`));
+      }
+    });
+  });
+}

--- a/src/libs/os/serial/prepare.ts
+++ b/src/libs/os/serial/prepare.ts
@@ -14,7 +14,7 @@ export default async (args: any): Promise<any> => {
 
     const guessed_portname = await SerialGuess();
     if (guessed_portname) {
-      console.log(`Guessed Serial Port ${portname}`);
+      console.log(`Guessed Serial Port ${guessed_portname}`);
       const use = await askUseGuessedPort(guessed_portname);
       if (use) {
         portname = guessed_portname;

--- a/src/libs/user/login.ts
+++ b/src/libs/user/login.ts
@@ -6,5 +6,5 @@ export default async () => {
   const token = await Login();
   const user = await User(token);
   Storage.set("token", token);
-  console.log(`Sigin in as "${user.email}"`);
+  console.log(`Sign in as "${user.email}"`);
 };


### PR DESCRIPTION
nodejs版obniz-cliだとシリアル通信を指定しないと自動推測される。
それをやめてpython版obniz_cliのように指定しなかったら一覧で出して選択させる方式に変更。

```bash
No port specified.
===Found Serial Ports===
0: /dev/tty.Bluetooth-Incoming-Port
1: /dev/tty.AeropexbyAfterShokz-GAIA
Select a port from the list above. (integer from 0 to 1)
```

推測成功時の挙動は

```bash
No port specified.
===Found Serial Ports===
0: /dev/tty.Bluetooth-Incoming-Port
1: /dev/tty.AeropexbyAfterShokz-GAIA
Guessed Serial Port {PORTNAME}
Use guessed port({PORTNAME})? (y or n)
```

となり，yを選択すると推測結果が用いられ，nを選択するとリストから選択するよう指示されます．